### PR TITLE
Optional subject

### DIFF
--- a/lib/six.rb
+++ b/lib/six.rb
@@ -159,7 +159,7 @@ class Six
   # == Returns:
   # true or false
   #
-  def allowed?(object, actions, subject)
+  def allowed?(object, actions, subject = nil)
     # if multiple actions passed
     # check all actions to be allowed
     if actions.respond_to?(:each)

--- a/spec/six_rules_packs_spec.rb
+++ b/spec/six_rules_packs_spec.rb
@@ -106,4 +106,27 @@ describe Six do
       it { abilities.pack_exist?(:ufo).should be_false }
     end
   end
+
+  describe "allowed? without subject" do
+    it "should default the subject to nil when passing it to the rules" do
+      rules = Class.new do
+        attr_accessor :subject_passed_to_me
+        def allowed(_, b)
+          self.subject_passed_to_me = b
+          []
+        end
+      end.new
+
+      abilities.add(:test, rules)
+
+      # default the subject to something
+      rules.subject_passed_to_me = Object.new
+
+      # call allowed without a subject
+      abilities.allowed?(Object.new, :irrelvant)
+
+      # was the subject passed in as nil?
+      rules.subject_passed_to_me.should be_nil
+    end
+  end
 end


### PR DESCRIPTION
``` ruby
# sometimes there may not be a "subject" to a rule

# like this... the rule is for ALL tvs, not nil or :any
abilities.allowed? my_two_year_old, :watch_tv, nil

# by making subject optional, the call to allowed? can be tighter
abilities.allowed? my_two_year_old, :watch_tv
```
