### PR TITLE
port specs to RSpec3

### DIFF
--- a/spec/six_rules_packs_spec.rb
+++ b/spec/six_rules_packs_spec.rb
@@ -9,7 +9,7 @@ describe Six do
     let(:rules) { BookRules.new }
 
     describe "<<" do
-      it { (abilities << rules).should be_true }
+      it { (abilities << rules).should be_truthy }
       it { lambda { abilities << nil }.should raise_error(Six::InvalidPackPassed) }
 
       it_should_behave_like :valid_abilities do
@@ -21,12 +21,12 @@ describe Six do
     end
 
     describe :add do
-      it { abilities.add(:global, rules).should be_true }
-      it { abilities.add(:wrong, nil).should be_false }
+      it { abilities.add(:global, rules).should be_truthy }
+      it { abilities.add(:wrong, nil).should be_falsey }
     end
 
     describe :add! do
-      it { abilities.add!(:global, rules).should be_true }
+      it { abilities.add!(:global, rules).should be_truthy }
       it { lambda { abilities.add!(:wrong, nil)}.should raise_error(Six::InvalidPackPassed) }
     end
 
@@ -45,7 +45,7 @@ describe Six do
         end
 
         it "should return false when trying to use unexisting pack" do
-          abilities.use(:noname).should be_false
+          abilities.use(:noname).should be_falsey
         end
       end
 
@@ -75,12 +75,12 @@ describe Six do
       before { abilities.add(:global, rules) }
 
       describe :remove do
-        it { abilities.remove(:global).should be_true }
-        it { abilities.remove(:zzz).should be_false }
+        it { abilities.remove(:global).should be_truthy }
+        it { abilities.remove(:zzz).should be_falsey }
       end
 
       describe :remove! do
-        it { abilities.remove!(:global).should be_true }
+        it { abilities.remove!(:global).should be_truthy }
         it { lambda { abilities.remove!(:zzz)}.should raise_error(Six::NoPackError) }
       end
     end
@@ -94,16 +94,16 @@ describe Six do
         Object.new
       end
 
-      it { abilities.valid_rules_object?(BookRules.new).should be_true }
-      it { abilities.valid_rules_object?(invalid_with_allowed).should be_false }
-      it { abilities.valid_rules_object?(invalid_wo_allowed).should be_false }
+      it { abilities.valid_rules_object?(BookRules.new).should be_truthy }
+      it { abilities.valid_rules_object?(invalid_with_allowed).should be_falsey }
+      it { abilities.valid_rules_object?(invalid_wo_allowed).should be_falsey }
     end
 
     describe :pack_exist? do
       before { abilities.add(:global, rules) }
 
-      it { abilities.pack_exist?(:global).should be_true }
-      it { abilities.pack_exist?(:ufo).should be_false }
+      it { abilities.pack_exist?(:global).should be_truthy }
+      it { abilities.pack_exist?(:ufo).should be_falsey }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,7 @@ require 'coveralls'
 Coveralls.wear!
 
 Dir[File.dirname(__FILE__) + '/support/*.rb'].each {|file| require file }
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = :should }
+end

--- a/spec/support/valid_abilities_example.rb
+++ b/spec/support/valid_abilities_example.rb
@@ -19,38 +19,38 @@ shared_examples :valid_abilities do
 
     describe "should return true or false depend on access" do 
       context :read_book do 
-        it { allowed?(@jim,  :read_book, @jims_book).should be_true }
-        it { allowed?(@mike, :read_book, @mikes_book).should be_true }
-        it { allowed?(@jim,  :read_book, @mikes_book).should be_true }
-        it { allowed?(@mike, :read_book, @jims_book).should be_true }
+        it { allowed?(@jim,  :read_book, @jims_book).should be_truthy }
+        it { allowed?(@mike, :read_book, @mikes_book).should be_truthy }
+        it { allowed?(@jim,  :read_book, @mikes_book).should be_truthy }
+        it { allowed?(@mike, :read_book, @jims_book).should be_truthy }
       end
 
       context :rate_book do 
-        it { allowed?(@jim,  :rate_book, @jims_book).should be_false }
-        it { allowed?(@mike, :rate_book, @mikes_book).should be_false }
-        it { allowed?(@jim,  :rate_book, @mikes_book).should be_true }
-        it { allowed?(@mike, :rate_book, @jims_book).should be_true }
+        it { allowed?(@jim,  :rate_book, @jims_book).should be_falsey }
+        it { allowed?(@mike, :rate_book, @mikes_book).should be_falsey }
+        it { allowed?(@jim,  :rate_book, @mikes_book).should be_truthy }
+        it { allowed?(@mike, :rate_book, @jims_book).should be_truthy }
       end
 
       context :edit_book do 
-        it { allowed?(@jim, :edit_book, @jims_book).should be_true }
-        it { allowed?(@mike,:edit_book,  @mikes_book).should be_true }
-        it { allowed?(@jim, :edit_book, @mikes_book).should be_false }
-        it { allowed?(@mike,:edit_book,  @jims_book).should be_false }
+        it { allowed?(@jim, :edit_book, @jims_book).should be_truthy }
+        it { allowed?(@mike,:edit_book,  @mikes_book).should be_truthy }
+        it { allowed?(@jim, :edit_book, @mikes_book).should be_falsey }
+        it { allowed?(@mike,:edit_book,  @jims_book).should be_falsey }
       end
 
       context :publish_book do 
-        it { allowed?(@jim, :publish_book, @jims_book).should be_false }
-        it { allowed?(@mike,:publish_book,  @mikes_book).should be_false }
-        it { allowed?(@jim, :publish_book, @mikes_book).should be_false }
-        it { allowed?(@mike,:publish_book,  @jims_book).should be_false }
+        it { allowed?(@jim, :publish_book, @jims_book).should be_falsey }
+        it { allowed?(@mike,:publish_book,  @mikes_book).should be_falsey }
+        it { allowed?(@jim, :publish_book, @mikes_book).should be_falsey }
+        it { allowed?(@mike,:publish_book,  @jims_book).should be_falsey }
       end
 
       context 'passing multiple actions' do 
-        it { allowed?(@jim, [:read_book, :edit_book], @jims_book).should be_true }
-        it { allowed?(@jim, [:ead_book,  :publish_book, :edit_book], @jims_book).should be_false }
-        it { allowed?(@mike, [:read_book, :edit_book], @mikes_book).should be_true }
-        it { allowed?(@mike, [:rate_book, :publish_book, :edit_book], @mikes_book).should be_false }
+        it { allowed?(@jim, [:read_book, :edit_book], @jims_book).should be_truthy }
+        it { allowed?(@jim, [:ead_book,  :publish_book, :edit_book], @jims_book).should be_falsey }
+        it { allowed?(@mike, [:read_book, :edit_book], @mikes_book).should be_truthy }
+        it { allowed?(@mike, [:rate_book, :publish_book, :edit_book], @mikes_book).should be_falsey }
       end
     end
   end


### PR DESCRIPTION
Port test suite to RSpec 3:
* add configuration option to allow 'old' `should` syntax
* use `be_truthy` and `be_falsey` instead of `be_true` and `be_false`